### PR TITLE
Image sizes and limit number of pages

### DIFF
--- a/README
+++ b/README
@@ -1,2 +1,0 @@
-Kodi addon to view photos from http://500px.com. This addon was created by Patrick L Archibald (PLA). The source for this addon can be found at https://github.com/pla1/plugin.image.500px.
-

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+## About
+
+Kodi addon to view photos from http://500px.com. This addon was created by Patrick L Archibald (PLA). The source for this addon can be found at https://github.com/pla1/plugin.image.500px.
+
+## Settings
+
+The addon has several settings you can configure:
+
+- Images per page: How many images to show on each page
+- Limit number of pages: If it should limit the number of pages shown
+  - Maximum number of pages: How many pages to show
+- Image size: The image size to fetch from 500px
+- Thumbnail size: The thumbnail size to fetch from 500px
+
+Limiting the number of pages shown is usefull if you want to limit the
+number of images to show in a recursive slideshow. 
+
+Information about the image and thumbnail sizes can be found at
+[Image URLs and Image Sizes](https://github.com/500px/api-documentation/blob/master/basics/formats_and_terms.md#image-urls-and-image-sizes)

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.image.500px" name="500px" version="0.2.4"
+<addon id="plugin.image.500px" name="500px" version="0.2.5"
        provider-name="Patrick L Archibald [patrick.archibald@gmail.com], Clément MATHIEU [clement@unportant.info]">
   <requires>
     <import addon="script.module.simplejson" version="2.0.10"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Version 0.2.5 - February 7, 2016
+- Added option to set which image and thumbnail sizes to fetch from 500px to get higher quality images.
+- Added option to limit the number of pages shown in image listings to make recursive slideshow more responsive.
 Version 0.2.4 - January 23, 2016
 - Replaced fanart and icon images with current 500px brand assets. https://about.500px.com/press/
 Version 0.2.3 - December 8, 2014

--- a/default.py
+++ b/default.py
@@ -17,6 +17,10 @@ from fivehundredpx.client import FiveHundredPXAPI
 
 _CONSUMER_KEY = 'LvUFQHMQgSlaWe3aRQot6Ct5ZC2pdTMyTLS0GMfF'
 _RPP = int(xbmcplugin.getSetting(fivehundredpxutils.xbmc.addon_handle, 'rpp'))
+_LIMITP = str(xbmcplugin.getSetting(fivehundredpxutils.xbmc.addon_handle, 'limitpages'))
+_MAXP = int(xbmcplugin.getSetting(fivehundredpxutils.xbmc.addon_handle, 'maxpages'))
+_IMGSIZE = int(xbmcplugin.getSetting(fivehundredpxutils.xbmc.addon_handle, 'imgsize'))
+_TMBSIZE = int(xbmcplugin.getSetting(fivehundredpxutils.xbmc.addon_handle, 'tmbsize'))
 API = FiveHundredPXAPI()
 
 
@@ -38,15 +42,16 @@ def feature():
     category = params.get('category', None)
     page = int(params.get('page', 1))
 
-    resp = API.photos(feature=feature, only=category, rpp=_RPP, consumer_key=_CONSUMER_KEY, image_size=[2, 4], page=page)
+    resp = API.photos(feature=feature, only=category, rpp=_RPP, consumer_key=_CONSUMER_KEY, image_size=[_TMBSIZE, _IMGSIZE], page=page)
 
     for image in map(Image, resp['photos']):
         fivehundredpxutils.xbmc.add_image(image)
 
-    if resp['current_page'] != resp['total_pages']:
-        next_page = page + 1
-        url = fivehundredpxutils.xbmc.encode_child_url('feature', feature=feature, category=category, page=next_page)
-        fivehundredpxutils.xbmc.add_dir('Next page', url)
+    if not (_LIMITP == 'true' and (resp['current_page'] >= _MAXP)):
+        if resp['current_page'] < resp['total_pages']:
+            next_page = page + 1
+            url = fivehundredpxutils.xbmc.encode_child_url('feature', feature=feature, category=category, page=next_page)
+            fivehundredpxutils.xbmc.add_dir('Next page', url)
 
     fivehundredpxutils.xbmc.end_of_directory()
 
@@ -69,7 +74,7 @@ def search():
         term = params['term']
         page = int(params.get('page', 1))
 
-    resp = API.photos_search(term=term, rpp=_RPP, consumer_key=_CONSUMER_KEY, image_size=[2, 4], page=page)
+    resp = API.photos_search(term=term, rpp=_RPP, consumer_key=_CONSUMER_KEY, image_size=[_TMBSIZE, _IMGSIZE], page=page)
     
     if (resp['total_items'] == 0):
         xbmc.executebuiltin('Notification(%s, %s)' % (__addonname__, "Your search returned no matches."))
@@ -78,13 +83,14 @@ def search():
     for image in map(Image, resp['photos']):
         fivehundredpxutils.xbmc.add_image(image)
 
-    if resp['current_page'] != resp['total_pages']:
-        next_page = page + 1
-        if 'ctxsearch' in params:
-            url = fivehundredpxutils.xbmc.encode_child_url('search', term=term, page=next_page, ctxsearch=True)
-        else:
-            url = fivehundredpxutils.xbmc.encode_child_url('search', term=term, page=next_page)
-        fivehundredpxutils.xbmc.add_dir('Next page', url)
+    if not (_LIMITP == 'true' and (resp['current_page'] >= _MAXP)):
+        if resp['current_page'] < resp['total_pages']:
+            next_page = page + 1
+            if 'ctxsearch' in params:
+                url = fivehundredpxutils.xbmc.encode_child_url('search', term=term, page=next_page, ctxsearch=True)
+            else:
+                url = fivehundredpxutils.xbmc.encode_child_url('search', term=term, page=next_page)
+            fivehundredpxutils.xbmc.add_dir('Next page', url)
 
     fivehundredpxutils.xbmc.end_of_directory()
 

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -8,5 +8,9 @@
   <string id="30005">Fresh today</string>
   <string id="30006">Fresh yesterday</string>
   <string id="30007">Fresh this week</string>
-  <string id="30008">Quantity</string>
+  <string id="30008">Images per page</string>
+  <string id="30009">Limit number of pages</string>
+  <string id="30010">Maximum number of pages</string>
+  <string id="30011">Image size</string>
+  <string id="30012">Thumbnail size</string>
 </strings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -2,5 +2,9 @@
 <settings>
   <category label="30000">
     <setting id="rpp" type="labelenum" label="30008" values="20|40|60|80|100" default="40"/>
+    <setting id="limitpages" type="bool" label="30009" default="false"/>    
+    <setting id="maxpages" type="labelenum" label="30010" enable="eq(-1,true)" subsetting="true" values="5|10|15|20|25" default="10"/>
+    <setting id="imgsize" type="labelenum" label="30011" values="4|5|6|20|21|30|31|1080|1600|2048" default="4"/>
+    <setting id="tmbsize" type="labelenum" label="30012" values="1|2|3|100|200|440|600" default="2"/>
   </category>
 </settings>


### PR DESCRIPTION
I added a couple of enhancements that you might consider. 

With bigger screens and higher available bandwidths it is nice to be able to have higher quality images. I added support for the current image sizes used by 500px API. 

Since the results from the API can include a high number of total pages, and recursive slideshow tries to fetch them all I added an option to limit the number of pages in the image listings. 

- Added option to set which image and thumbnail sizes to fetch from 500px to get higher quality images.
- Added option to limit the number of pages shown in image listings to make recursive slideshow more responsive.