### PR TITLE
Fixed Kodi behaviour where UI did not react on picture context items …

### DIFF
--- a/resources/lib/fivehundredpxutils/xbmc.py
+++ b/resources/lib/fivehundredpxutils/xbmc.py
@@ -40,7 +40,15 @@ def add_dir(name, url, thumb=None):
 def add_image(image):
     item = xbmcgui.ListItem(image.name)
     item.setArt({'thumb': image.thumb_url})
-    
+    item.setInfo(
+        type='pictures', 
+        infoLabels={ 
+            "title": image.name, 
+            "picturepath": image.url,
+            "exif:path": image.url
+        }
+    )
+
     if not 'ctxsearch' in addon_params:
         label = "More from %s" % image.userfullname # i18n
         url = encode_child_url('search', term=image.username, ctxsearch=True)


### PR DESCRIPTION
…like 'Picture Info' or 'Start Slideshow'.

500px URLs do not have extensions and in order to tell Kodi that the URL is indeed image, setInfo with any exif: tag is required.

The cause is CGUIWindowPictures::OnInfo implementation which activates context menu items if item->IsPicture() is true. This typically happens if the URL ends with image extension like .jpg. If it is not the case (for example at 500px), the CFileItem::HasPictureInfoTag must return true. This happens if in the plugin script the setInfo is called for type 'pictures' with at least one 'exif:' label, see ListItem::setInfo.